### PR TITLE
Add devcontainer setup for local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,72 @@
+FROM mcr.microsoft.com/devcontainers/base:debian-12
+
+ARG PMD_VERSION="7.22.0"
+
+ENV PATH="/usr/local/bin:/opt/uv-python/current/bin:${PATH}"
+ENV UV_PYTHON_INSTALL_DIR="/opt/uv-python"
+
+USER root
+
+RUN set -eux; \
+  apt-get update; \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    findutils \
+    git \
+    jq \
+    openjdk-17-jre-headless \
+    sudo \
+    tar \
+    unzip \
+    ; \
+  rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+  curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg -o /usr/share/keyrings/tailscale-archive-keyring.gpg; \
+  curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list -o /etc/apt/sources.list.d/tailscale.list; \
+  apt-get update; \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tailscale; \
+  rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+  curl -LsSf https://astral.sh/uv/install.sh | sh; \
+  install -m 0755 /root/.local/bin/uv /usr/local/bin/uv; \
+  rm -rf /root/.local; \
+  uv python install 3.12 --install-dir "${UV_PYTHON_INSTALL_DIR}"; \
+  python_bin="$(find "${UV_PYTHON_INSTALL_DIR}" -type f -path '*/bin/python3.12' | head -n 1)"; \
+  test -n "${python_bin}"; \
+  python_home="$(dirname "$(dirname "${python_bin}")")"; \
+  ln -sfn "${python_home}" /opt/uv-python/current; \
+  ln -sf /opt/uv-python/current/bin/python3.12 /usr/local/bin/python3.12; \
+  ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3; \
+  ln -sf /usr/local/bin/python3.12 /usr/local/bin/python
+
+RUN set -eux; \
+  curl -sSLo /tmp/pmd.zip "https://github.com/pmd/pmd/releases/download/pmd_releases%2F${PMD_VERSION}/pmd-dist-${PMD_VERSION}-bin.zip"; \
+  unzip -q /tmp/pmd.zip -d /opt; \
+  ln -sf "/opt/pmd-bin-${PMD_VERSION}/bin/pmd" /usr/local/bin/pmd; \
+  rm /tmp/pmd.zip
+
+RUN set -eux; \
+  if ! id -u devcontainer-user >/dev/null 2>&1; then \
+    existing_user="$(getent passwd 1000 | cut -d: -f1 || true)"; \
+    if [ -n "${existing_user}" ]; then \
+      if [ "${existing_user}" != "devcontainer-user" ]; then usermod -l devcontainer-user "${existing_user}"; fi; \
+      existing_group="$(getent group 1000 | cut -d: -f1 || true)"; \
+      if [ -n "${existing_group}" ] && [ "${existing_group}" != "devcontainer-user" ]; then groupmod -n devcontainer-user "${existing_group}" || true; fi; \
+      usermod -d /home/devcontainer-user -m devcontainer-user; \
+    else \
+      if ! getent group 1000 >/dev/null 2>&1; then groupadd --gid 1000 devcontainer-user; fi; \
+      useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash devcontainer-user; \
+    fi; \
+  fi; \
+  usermod -aG sudo devcontainer-user; \
+  echo "devcontainer-user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/devcontainer-user; \
+  chmod 0440 /etc/sudoers.d/devcontainer-user; \
+  mkdir -p /var/lib/tailscale; \
+  chown -R devcontainer-user:devcontainer-user /var/lib/tailscale; \
+  chown -R devcontainer-user:devcontainer-user "${UV_PYTHON_INSTALL_DIR}"; \
+  chmod -R g+w "${UV_PYTHON_INSTALL_DIR}"
+
+USER devcontainer-user

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+    "name": "longtail-experiment",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "init": true,
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2.14.0": {},
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "22"
+        }
+    },
+    "remoteUser": "devcontainer-user",
+    "updateRemoteUserUID": true,
+    "runArgs": [
+        "--privileged"
+    ],
+    "mounts": [
+        "source=longtail-experiment-docker-lib,target=/var/lib/docker,type=volume",
+        "source=longtail-experiment-tailscale-state,target=/var/lib/tailscale,type=volume"
+    ],
+    "containerEnv": {
+        "OPENCODE_SERVER_HOSTNAME": "0.0.0.0",
+        "OPENCODE_SERVER_PORT": "4096"
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python3.12",
+                "python.terminal.activateEnvironment": true,
+                "ruff.nativeServer": true
+            },
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "charliermarsh.ruff",
+                "ms-toolsai.jupyter",
+                "ms-azuretools.vscode-docker",
+                "nrwl.angular-console",
+                "biomejs.biome"
+            ]
+        }
+    },
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "8gb"
+    },
+    "postCreateCommand": "bash .devcontainer/postCreate.sh",
+    "postStartCommand": "bash .devcontainer/postStart.sh"
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is not installed or not on PATH." >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is not installed or not on PATH." >&2
+  exit 1
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable
+  corepack prepare pnpm@9.0.0 --activate
+fi
+
+if [[ -f "docker/compose/local.secrets.env.example" ]] && [[ ! -f "docker/compose/local.secrets.env" ]]; then
+  cp docker/compose/local.secrets.env.example docker/compose/local.secrets.env
+  echo "Created docker/compose/local.secrets.env from example."
+fi
+
+echo "Installing Node workspace dependencies..."
+pnpm install
+
+if ! command -v opencode >/dev/null 2>&1; then
+  echo "Installing opencode CLI..."
+  npm_bin="$(command -v npm || true)"
+  if [[ -z "${npm_bin}" ]]; then
+    echo "npm is not installed or not on PATH." >&2
+    exit 1
+  fi
+
+  if ! "${npm_bin}" install -g opencode-ai; then
+    sudo "${npm_bin}" install -g opencode-ai
+  fi
+fi
+
+echo "opencode version: $(opencode --version)"
+
+echo "Syncing Python project environments..."
+mapfile -t pyprojects < <(find apps libs -mindepth 2 -maxdepth 2 -name pyproject.toml | sort)
+
+for pyproject in "${pyprojects[@]}"; do
+  project_dir="$(dirname "${pyproject}")"
+  echo "- uv sync --project ${project_dir}"
+  uv sync --project "${project_dir}" --frozen
+done
+
+echo "Installing pre-commit hooks (best effort)..."
+uvx --from pre-commit pre-commit install --install-hooks || true
+
+echo "Devcontainer bootstrap complete."

--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker CLI is not installed in this devcontainer." >&2
+  exit 1
+fi
+
+if ! command -v tailscaled >/dev/null 2>&1 || ! command -v tailscale >/dev/null 2>&1; then
+  echo "Tailscale is not installed in this devcontainer image." >&2
+  exit 1
+fi
+
+timeout_sec="${DOCKER_STARTUP_TIMEOUT_SEC:-30}"
+docker_ready="false"
+
+echo "Waiting for Docker daemon to be ready (timeout: ${timeout_sec}s)..." >&2
+for _ in $(seq 1 "${timeout_sec}"); do
+  if docker info >/dev/null 2>&1 || sudo -n docker info >/dev/null 2>&1; then
+    if docker compose version >/dev/null 2>&1; then
+      docker_ready="true"
+      break
+    fi
+  fi
+  sleep 1
+done
+
+if [[ "${docker_ready}" != "true" ]]; then
+  echo "Docker is not available inside this devcontainer after ${timeout_sec}s." >&2
+  echo "Debug info:" >&2
+  echo "- docker version:" >&2
+  docker version >&2 || true
+  echo "- docker compose version:" >&2
+  docker compose version >&2 || true
+  exit 1
+fi
+
+if ! pgrep -x tailscaled >/dev/null 2>&1; then
+  echo "Starting tailscaled daemon..." >&2
+  sudo mkdir -p /var/lib/tailscale
+  sudo chown devcontainer-user:devcontainer-user /var/lib/tailscale
+  nohup sudo tailscaled --statedir=/var/lib/tailscale >/tmp/tailscaled.log 2>&1 &
+fi
+
+echo "Checking Tailscale daemon status..." >&2
+if sudo tailscale status >/dev/null 2>&1; then
+  echo "Tailscale daemon is running."
+else
+  echo "Tailscale daemon is starting."
+fi
+
+echo "To authenticate manually, run: sudo tailscale up --auth-key=<tskey-...>"
+
+if ! command -v opencode >/dev/null 2>&1; then
+  echo "opencode CLI is not installed yet. Rebuild the devcontainer or run: sudo npm install -g opencode-ai" >&2
+  exit 0
+fi
+
+opencode_host="${OPENCODE_SERVER_HOSTNAME:-0.0.0.0}"
+opencode_port="${OPENCODE_SERVER_PORT:-4096}"
+opencode_log="/tmp/opencode-serve.log"
+
+if pgrep -f "opencode serve" >/dev/null 2>&1; then
+  echo "opencode serve is already running."
+else
+  echo "Starting opencode serve on ${opencode_host}:${opencode_port}..."
+  nohup opencode serve --hostname "${opencode_host}" --port "${opencode_port}" >"${opencode_log}" 2>&1 &
+fi
+
+echo "opencode log: ${opencode_log}"


### PR DESCRIPTION
## Summary
- add a `.devcontainer` configuration for this repo mirroring the existing setup used in the sibling monorepo
- include a custom devcontainer image with Python 3.12, Node 22, Docker-in-Docker, Tailscale, and PMD available out of the box
- add post-create and post-start bootstrap scripts to install dependencies, sync Python projects, and start local devcontainer services